### PR TITLE
Add WPF calculator application

### DIFF
--- a/CalcApp/App.xaml
+++ b/CalcApp/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="CalcApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/CalcApp/App.xaml.cs
+++ b/CalcApp/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace CalcApp;
+
+public partial class App : Application
+{
+}

--- a/CalcApp/CalcApp.csproj
+++ b/CalcApp/CalcApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -1,0 +1,55 @@
+<Window x:Class="CalcApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Számológép" Height="450" Width="350" ResizeMode="CanMinimize">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Border CornerRadius="8" BorderBrush="#FFB0B0B0" BorderThickness="1" Padding="8" Background="#FFF3F3F3">
+            <TextBox x:Name="Display" FontSize="32" HorizontalAlignment="Stretch" VerticalAlignment="Center"
+                     Text="0" TextAlignment="Right" IsReadOnly="True" BorderThickness="0" Background="Transparent" />
+        </Border>
+
+        <Grid Grid.Row="1" Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition />
+                <ColumnDefinition />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+
+            <Button Content="C" Click="Clear_Click" FontSize="20" Grid.Row="0" Grid.Column="0" />
+            <Button Content="±" Click="Sign_Click" FontSize="20" Grid.Row="0" Grid.Column="1" />
+            <Button Content="%" Click="Percent_Click" FontSize="20" Grid.Row="0" Grid.Column="2" />
+            <Button Content="÷" Click="Operator_Click" FontSize="20" Grid.Row="0" Grid.Column="3" Tag="/" />
+
+            <Button Content="7" Click="Digit_Click" FontSize="20" Grid.Row="1" Grid.Column="0" />
+            <Button Content="8" Click="Digit_Click" FontSize="20" Grid.Row="1" Grid.Column="1" />
+            <Button Content="9" Click="Digit_Click" FontSize="20" Grid.Row="1" Grid.Column="2" />
+            <Button Content="×" Click="Operator_Click" FontSize="20" Grid.Row="1" Grid.Column="3" Tag="*" />
+
+            <Button Content="4" Click="Digit_Click" FontSize="20" Grid.Row="2" Grid.Column="0" />
+            <Button Content="5" Click="Digit_Click" FontSize="20" Grid.Row="2" Grid.Column="1" />
+            <Button Content="6" Click="Digit_Click" FontSize="20" Grid.Row="2" Grid.Column="2" />
+            <Button Content="−" Click="Operator_Click" FontSize="20" Grid.Row="2" Grid.Column="3" Tag="-" />
+
+            <Button Content="1" Click="Digit_Click" FontSize="20" Grid.Row="3" Grid.Column="0" />
+            <Button Content="2" Click="Digit_Click" FontSize="20" Grid.Row="3" Grid.Column="1" />
+            <Button Content="3" Click="Digit_Click" FontSize="20" Grid.Row="3" Grid.Column="2" />
+            <Button Content="+" Click="Operator_Click" FontSize="20" Grid.Row="3" Grid.Column="3" Tag="+" />
+
+            <Button Content="0" Click="Digit_Click" FontSize="20" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" />
+            <Button Content="," Click="Decimal_Click" FontSize="20" Grid.Row="4" Grid.Column="2" />
+            <Button Content="=" Click="Equals_Click" FontSize="20" Grid.Row="4" Grid.Column="3" />
+        </Grid>
+    </Grid>
+</Window>

--- a/CalcApp/MainWindow.xaml.cs
+++ b/CalcApp/MainWindow.xaml.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace CalcApp;
+
+public partial class MainWindow : Window
+{
+    private double? _leftOperand;
+    private string? _pendingOperator;
+    private bool _shouldResetDisplay;
+
+    private readonly string _decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void Digit_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button)
+        {
+            return;
+        }
+
+        var digit = button.Content?.ToString() ?? string.Empty;
+
+        if (_shouldResetDisplay || Display.Text == "0")
+        {
+            Display.Text = digit;
+        }
+        else
+        {
+            Display.Text += digit;
+        }
+
+        _shouldResetDisplay = false;
+    }
+
+    private void Decimal_Click(object sender, RoutedEventArgs e)
+    {
+        if (_shouldResetDisplay)
+        {
+            Display.Text = "0" + _decimalSeparator;
+            _shouldResetDisplay = false;
+            return;
+        }
+
+        if (!Display.Text.Contains(_decimalSeparator, StringComparison.Ordinal))
+        {
+            Display.Text += _decimalSeparator;
+        }
+    }
+
+    private void Clear_Click(object sender, RoutedEventArgs e)
+    {
+        Display.Text = "0";
+        _leftOperand = null;
+        _pendingOperator = null;
+        _shouldResetDisplay = false;
+    }
+
+    private void Sign_Click(object sender, RoutedEventArgs e)
+    {
+        if (double.TryParse(Display.Text, NumberStyles.Float, CultureInfo.CurrentCulture, out var value))
+        {
+            value *= -1;
+            Display.Text = value.ToString(CultureInfo.CurrentCulture);
+        }
+    }
+
+    private void Percent_Click(object sender, RoutedEventArgs e)
+    {
+        if (double.TryParse(Display.Text, NumberStyles.Float, CultureInfo.CurrentCulture, out var value))
+        {
+            value /= 100;
+            Display.Text = value.ToString(CultureInfo.CurrentCulture);
+        }
+    }
+
+    private void Operator_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button)
+        {
+            return;
+        }
+
+        var operatorSymbol = button.Tag?.ToString() ?? button.Content?.ToString();
+        if (string.IsNullOrWhiteSpace(operatorSymbol))
+        {
+            return;
+        }
+
+        if (double.TryParse(Display.Text, NumberStyles.Float, CultureInfo.CurrentCulture, out var currentValue))
+        {
+            if (_leftOperand.HasValue && _pendingOperator is not null && !_shouldResetDisplay)
+            {
+                _leftOperand = Evaluate(_leftOperand.Value, currentValue, _pendingOperator);
+                Display.Text = _leftOperand?.ToString(CultureInfo.CurrentCulture) ?? "0";
+            }
+            else
+            {
+                _leftOperand = currentValue;
+            }
+
+            _pendingOperator = operatorSymbol;
+            _shouldResetDisplay = true;
+        }
+    }
+
+    private void Equals_Click(object sender, RoutedEventArgs e)
+    {
+        if (_leftOperand.HasValue && _pendingOperator is not null && double.TryParse(Display.Text, NumberStyles.Float, CultureInfo.CurrentCulture, out var rightOperand))
+        {
+            try
+            {
+                var result = Evaluate(_leftOperand.Value, rightOperand, _pendingOperator);
+                Display.Text = result.ToString(CultureInfo.CurrentCulture);
+                _leftOperand = null;
+                _pendingOperator = null;
+                _shouldResetDisplay = true;
+            }
+            catch (DivideByZeroException)
+            {
+                Display.Text = "Hiba";
+                _leftOperand = null;
+                _pendingOperator = null;
+                _shouldResetDisplay = true;
+            }
+        }
+    }
+
+    private static double Evaluate(double left, double right, string operatorSymbol)
+    {
+        return operatorSymbol switch
+        {
+            "+" => left + right,
+            "-" => left - right,
+            "*" => left * right,
+            "/" => right == 0 ? throw new DivideByZeroException() : left / right,
+            _ => right
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add a .NET 8 WPF project configured for Windows desktop
- implement calculator window with buttons for digits and operations
- handle arithmetic, percent, sign toggle, and clear actions in code-behind

## Testing
- not run (dotnet SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e24aa055948325846ae61dac89eae0