### PR TITLE
Add scientific functions and dark mode to calculator

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -1,24 +1,65 @@
 <Window x:Class="CalcApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Számológép" Height="450" Width="350" ResizeMode="CanMinimize">
+        Title="Calculator" Height="520" Width="380" ResizeMode="CanMinimize"
+        Background="{DynamicResource WindowBackgroundBrush}">
+    <Window.Resources>
+        <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FFF5F5F5" />
+        <SolidColorBrush x:Key="BorderBackgroundBrush" Color="#FFFFFFFF" />
+        <SolidColorBrush x:Key="BorderForegroundBrush" Color="#FF1F1F1F" />
+        <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FFE0E0E0" />
+        <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FF1F1F1F" />
+        <SolidColorBrush x:Key="AccentButtonBrush" Color="#FF7FB4FF" />
+        <Style TargetType="Button">
+            <Setter Property="Margin" Value="4" />
+            <Setter Property="FontSize" Value="18" />
+            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundBrush}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="8" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+    </Window.Resources>
+
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Border CornerRadius="8" BorderBrush="#FFB0B0B0" BorderThickness="1" Padding="8" Background="#FFF3F3F3">
-            <TextBox x:Name="Display" FontSize="32" HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                     Text="0" TextAlignment="Right" IsReadOnly="True" BorderThickness="0" Background="Transparent" />
-        </Border>
 
-        <Grid Grid.Row="1" Margin="0,12,0,0">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Border CornerRadius="8" BorderBrush="#FFB0B0B0" BorderThickness="1" Padding="8"
+                    Background="{DynamicResource BorderBackgroundBrush}">
+                <TextBox x:Name="Display" FontSize="36" HorizontalAlignment="Stretch" VerticalAlignment="Center"
+                         Text="0" TextAlignment="Right" IsReadOnly="True" BorderThickness="0"
+                         Background="Transparent" Foreground="{DynamicResource BorderForegroundBrush}" />
+            </Border>
+
+            <ToggleButton x:Name="DarkModeToggle" Content="Dark mode" Grid.Column="1" Margin="12,0,0,0"
+                          VerticalAlignment="Center" Padding="12,8" Checked="DarkModeToggle_OnChecked"
+                          Unchecked="DarkModeToggle_OnUnchecked"
+                          Foreground="{DynamicResource BorderForegroundBrush}" />
+        </Grid>
+
+        <TextBlock x:Name="MemoryText" Grid.Row="1" Text="" FontSize="14" Margin="4,8,4,12"
+                   HorizontalAlignment="Right" Foreground="{DynamicResource BorderForegroundBrush}" />
+
+        <Grid Grid.Row="2">
             <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
@@ -27,29 +68,43 @@
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
-            <Button Content="C" Click="Clear_Click" FontSize="20" Grid.Row="0" Grid.Column="0" />
-            <Button Content="±" Click="Sign_Click" FontSize="20" Grid.Row="0" Grid.Column="1" />
-            <Button Content="%" Click="Percent_Click" FontSize="20" Grid.Row="0" Grid.Column="2" />
-            <Button Content="÷" Click="Operator_Click" FontSize="20" Grid.Row="0" Grid.Column="3" Tag="/" />
+            <Button Content="sin" Grid.Row="0" Grid.Column="0" Click="Sin_Click" />
+            <Button Content="cos" Grid.Row="0" Grid.Column="1" Click="Cos_Click" />
+            <Button Content="tan" Grid.Row="0" Grid.Column="2" Click="Tan_Click" />
+            <Button Content="√" Grid.Row="0" Grid.Column="3" Click="Sqrt_Click" />
 
-            <Button Content="7" Click="Digit_Click" FontSize="20" Grid.Row="1" Grid.Column="0" />
-            <Button Content="8" Click="Digit_Click" FontSize="20" Grid.Row="1" Grid.Column="1" />
-            <Button Content="9" Click="Digit_Click" FontSize="20" Grid.Row="1" Grid.Column="2" />
-            <Button Content="×" Click="Operator_Click" FontSize="20" Grid.Row="1" Grid.Column="3" Tag="*" />
+            <Button Content="n!" Grid.Row="1" Grid.Column="0" Click="Factorial_Click" />
+            <Button Content="M+" Grid.Row="1" Grid.Column="1" Click="MemoryAdd_Click" />
+            <Button Content="M-" Grid.Row="1" Grid.Column="2" Click="MemorySubtract_Click" />
+            <Button Content="MR" Grid.Row="1" Grid.Column="3" Click="MemoryRecall_Click" />
 
-            <Button Content="4" Click="Digit_Click" FontSize="20" Grid.Row="2" Grid.Column="0" />
-            <Button Content="5" Click="Digit_Click" FontSize="20" Grid.Row="2" Grid.Column="1" />
-            <Button Content="6" Click="Digit_Click" FontSize="20" Grid.Row="2" Grid.Column="2" />
-            <Button Content="−" Click="Operator_Click" FontSize="20" Grid.Row="2" Grid.Column="3" Tag="-" />
+            <Button Content="MC" Grid.Row="2" Grid.Column="0" Click="MemoryClear_Click" />
+            <Button Content="C" Grid.Row="2" Grid.Column="1" Click="Clear_Click" />
+            <Button Content="⌫" Grid.Row="2" Grid.Column="2" Click="Delete_Click" />
+            <Button Content="%" Grid.Row="2" Grid.Column="3" Click="Percent_Click" />
 
-            <Button Content="1" Click="Digit_Click" FontSize="20" Grid.Row="3" Grid.Column="0" />
-            <Button Content="2" Click="Digit_Click" FontSize="20" Grid.Row="3" Grid.Column="1" />
-            <Button Content="3" Click="Digit_Click" FontSize="20" Grid.Row="3" Grid.Column="2" />
-            <Button Content="+" Click="Operator_Click" FontSize="20" Grid.Row="3" Grid.Column="3" Tag="+" />
+            <Button Content="7" Grid.Row="3" Grid.Column="0" Click="Digit_Click" />
+            <Button Content="8" Grid.Row="3" Grid.Column="1" Click="Digit_Click" />
+            <Button Content="9" Grid.Row="3" Grid.Column="2" Click="Digit_Click" />
+            <Button Content="÷" Grid.Row="3" Grid.Column="3" Click="Operator_Click" Tag="/" />
 
-            <Button Content="0" Click="Digit_Click" FontSize="20" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" />
-            <Button Content="," Click="Decimal_Click" FontSize="20" Grid.Row="4" Grid.Column="2" />
-            <Button Content="=" Click="Equals_Click" FontSize="20" Grid.Row="4" Grid.Column="3" />
+            <Button Content="4" Grid.Row="4" Grid.Column="0" Click="Digit_Click" />
+            <Button Content="5" Grid.Row="4" Grid.Column="1" Click="Digit_Click" />
+            <Button Content="6" Grid.Row="4" Grid.Column="2" Click="Digit_Click" />
+            <Button Content="×" Grid.Row="4" Grid.Column="3" Click="Operator_Click" Tag="*" />
+
+            <Button Content="1" Grid.Row="5" Grid.Column="0" Click="Digit_Click" />
+            <Button Content="2" Grid.Row="5" Grid.Column="1" Click="Digit_Click" />
+            <Button Content="3" Grid.Row="5" Grid.Column="2" Click="Digit_Click" />
+            <Button Content="−" Grid.Row="5" Grid.Column="3" Click="Operator_Click" Tag="-" />
+
+            <Button Content="0" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Click="Digit_Click" />
+            <Button Content="." Grid.Row="6" Grid.Column="2" Click="Decimal_Click" />
+            <Button Content="+" Grid.Row="6" Grid.Column="3" Click="Operator_Click" Tag="+" />
+
+            <Button Content="±" Grid.Row="7" Grid.Column="0" Click="Sign_Click" />
+            <Button Content="=" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Click="Equals_Click"
+                    Background="{DynamicResource AccentButtonBrush}" />
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- redesign the calculator layout with English labels, additional scientific keys, and memory controls
- add a dark mode toggle with dynamic resource updates and theme-aware styling
- extend the code-behind to support trigonometry, square root, factorial, percent, delete, and memory operations with improved error handling

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27ba31a508325b4f86c6c0f900a35