### PR TITLE
Allow resizing and show full button grid

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="CalcApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Calculator" Height="520" Width="380" ResizeMode="CanMinimize"
+        Title="Calculator" Width="380" MinWidth="360" Height="560" MinHeight="520" ResizeMode="CanResize"
         Background="{DynamicResource WindowBackgroundBrush}">
     <Window.Resources>
         <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FFF5F5F5" />
@@ -52,20 +52,20 @@
 
         <Grid Grid.Row="2">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-                <ColumnDefinition />
-                <ColumnDefinition />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
             <Button Content="sin" Grid.Row="0" Grid.Column="0" Click="Sin_Click" />


### PR DESCRIPTION
## Summary
- allow the calculator window to be resized and maximized by enabling standard resize mode
- increase the default and minimum window size so the bottom controls remain visible
- let the button grid stretch evenly with the window to keep all rows visible when resizing

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27def328c832583c647accd7fd890