### PR TITLE
Add Material You dark theme toggle

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -18,6 +18,29 @@
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Padding" Value="8" />
             <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="ButtonBorder"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="14"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.85" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.6" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
     </Window.Resources>
 
@@ -34,16 +57,16 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Border CornerRadius="8" BorderBrush="#FFB0B0B0" BorderThickness="1" Padding="8"
+            <Border CornerRadius="12" BorderBrush="#FFB0B0B0" BorderThickness="1" Padding="8"
                     Background="{DynamicResource BorderBackgroundBrush}">
                 <TextBox x:Name="Display" FontSize="36" HorizontalAlignment="Stretch" VerticalAlignment="Center"
                          Text="0" TextAlignment="Right" IsReadOnly="True" BorderThickness="0"
                          Background="Transparent" Foreground="{DynamicResource BorderForegroundBrush}" />
             </Border>
 
-            <ToggleButton x:Name="DarkModeToggle" Content="Dark mode" Grid.Column="1" Margin="12,0,0,0"
-                          VerticalAlignment="Center" Padding="12,8" Checked="DarkModeToggle_OnChecked"
-                          Unchecked="DarkModeToggle_OnUnchecked"
+            <ToggleButton x:Name="MaterialThemeToggle" Content="Material You" Grid.Column="1" Margin="12,0,0,0"
+                          VerticalAlignment="Center" Padding="12,8" Checked="MaterialThemeToggle_OnChecked"
+                          Unchecked="MaterialThemeToggle_OnUnchecked"
                           Foreground="{DynamicResource BorderForegroundBrush}" />
         </Grid>
 

--- a/CalcApp/MainWindow.xaml.cs
+++ b/CalcApp/MainWindow.xaml.cs
@@ -12,7 +12,7 @@ public partial class MainWindow : Window
     private string? _pendingOperator;
     private bool _shouldResetDisplay;
     private double _memory;
-    private bool _isDarkMode;
+    private bool _useMaterialYou;
 
     private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
 
@@ -259,15 +259,15 @@ public partial class MainWindow : Window
         UpdateMemoryDisplay();
     }
 
-    private void DarkModeToggle_OnChecked(object sender, RoutedEventArgs e)
+    private void MaterialThemeToggle_OnChecked(object sender, RoutedEventArgs e)
     {
-        _isDarkMode = true;
+        _useMaterialYou = true;
         ApplyTheme();
     }
 
-    private void DarkModeToggle_OnUnchecked(object sender, RoutedEventArgs e)
+    private void MaterialThemeToggle_OnUnchecked(object sender, RoutedEventArgs e)
     {
-        _isDarkMode = false;
+        _useMaterialYou = false;
         ApplyTheme();
     }
 
@@ -315,18 +315,24 @@ public partial class MainWindow : Window
 
     private void ApplyTheme()
     {
-        var windowBackground = _isDarkMode ? Color.FromRgb(18, 18, 18) : Color.FromRgb(245, 245, 245);
-        var borderBackground = _isDarkMode ? Color.FromRgb(33, 33, 33) : Colors.White;
-        var foreground = _isDarkMode ? Colors.White : Color.FromRgb(31, 31, 31);
-        var buttonBackground = _isDarkMode ? Color.FromRgb(56, 56, 56) : Color.FromRgb(224, 224, 224);
-        var accent = _isDarkMode ? Color.FromRgb(98, 0, 238) : Color.FromRgb(127, 180, 255);
-
-        Resources["WindowBackgroundBrush"] = new SolidColorBrush(windowBackground);
-        Resources["BorderBackgroundBrush"] = new SolidColorBrush(borderBackground);
-        Resources["BorderForegroundBrush"] = new SolidColorBrush(foreground);
-        Resources["ButtonBackgroundBrush"] = new SolidColorBrush(buttonBackground);
-        Resources["ButtonForegroundBrush"] = new SolidColorBrush(foreground);
-        Resources["AccentButtonBrush"] = new SolidColorBrush(accent);
+        if (_useMaterialYou)
+        {
+            Resources["WindowBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(18, 18, 18));
+            Resources["BorderBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(28, 27, 31));
+            Resources["BorderForegroundBrush"] = new SolidColorBrush(Color.FromRgb(232, 224, 255));
+            Resources["ButtonBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(49, 48, 56));
+            Resources["ButtonForegroundBrush"] = new SolidColorBrush(Color.FromRgb(232, 224, 255));
+            Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(147, 118, 255));
+        }
+        else
+        {
+            Resources["WindowBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(245, 245, 245));
+            Resources["BorderBackgroundBrush"] = new SolidColorBrush(Colors.White);
+            Resources["BorderForegroundBrush"] = new SolidColorBrush(Color.FromRgb(31, 31, 31));
+            Resources["ButtonBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(224, 224, 224));
+            Resources["ButtonForegroundBrush"] = new SolidColorBrush(Color.FromRgb(31, 31, 31));
+            Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(127, 180, 255));
+        }
     }
 
     private void ResetCalculatorState()


### PR DESCRIPTION
## Summary
- replace the dark mode toggle with a Material You toggle that switches between the classic look and a new dark theme
- implement Material You-inspired dark palette and update resource brushes accordingly
- round button corners in both themes via a custom template

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27fe17f048325ad782d85c33f9cb8