### PR TITLE
Refine dark theme toggle views

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -4,12 +4,12 @@
         Title="Calculator" Width="380" MinWidth="360" Height="560" MinHeight="520" ResizeMode="CanResize"
         Background="{DynamicResource WindowBackgroundBrush}">
     <Window.Resources>
-        <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FFF5F5F5" />
-        <SolidColorBrush x:Key="BorderBackgroundBrush" Color="#FFFFFFFF" />
-        <SolidColorBrush x:Key="BorderForegroundBrush" Color="#FF1F1F1F" />
-        <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FFE0E0E0" />
-        <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FF1F1F1F" />
-        <SolidColorBrush x:Key="AccentButtonBrush" Color="#FF7FB4FF" />
+        <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FF121212" />
+        <SolidColorBrush x:Key="BorderBackgroundBrush" Color="#FF1F1F1F" />
+        <SolidColorBrush x:Key="BorderForegroundBrush" Color="#FFF2F2F2" />
+        <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FF2A2A2A" />
+        <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FFF2F2F2" />
+        <SolidColorBrush x:Key="AccentButtonBrush" Color="#FF3D7DFF" />
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4" />
             <Setter Property="FontSize" Value="18" />
@@ -18,6 +18,29 @@
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Padding" Value="8" />
             <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="ButtonBorder"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="14"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.85" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.6" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
     </Window.Resources>
 
@@ -34,17 +57,18 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Border CornerRadius="8" BorderBrush="#FFB0B0B0" BorderThickness="1" Padding="8"
+            <Border CornerRadius="12" BorderBrush="#FFB0B0B0" BorderThickness="1" Padding="8"
                     Background="{DynamicResource BorderBackgroundBrush}">
                 <TextBox x:Name="Display" FontSize="36" HorizontalAlignment="Stretch" VerticalAlignment="Center"
                          Text="0" TextAlignment="Right" IsReadOnly="True" BorderThickness="0"
                          Background="Transparent" Foreground="{DynamicResource BorderForegroundBrush}" />
             </Border>
 
-            <ToggleButton x:Name="DarkModeToggle" Content="Dark mode" Grid.Column="1" Margin="12,0,0,0"
-                          VerticalAlignment="Center" Padding="12,8" Checked="DarkModeToggle_OnChecked"
-                          Unchecked="DarkModeToggle_OnUnchecked"
-                          Foreground="{DynamicResource BorderForegroundBrush}" />
+            <ToggleButton x:Name="MaterialThemeToggle" Content="Klasszikus nézet" Grid.Column="1" Margin="12,0,0,0"
+                          VerticalAlignment="Center" Padding="12,8" Checked="MaterialThemeToggle_OnChecked"
+                          Unchecked="MaterialThemeToggle_OnUnchecked"
+                          Foreground="{DynamicResource BorderForegroundBrush}"
+                          Background="{DynamicResource ButtonBackgroundBrush}" />
         </Grid>
 
         <TextBlock x:Name="MemoryText" Grid.Row="1" Text="" FontSize="14" Margin="4,8,4,12"

--- a/CalcApp/MainWindow.xaml.cs
+++ b/CalcApp/MainWindow.xaml.cs
@@ -12,7 +12,7 @@ public partial class MainWindow : Window
     private string? _pendingOperator;
     private bool _shouldResetDisplay;
     private double _memory;
-    private bool _isDarkMode;
+    private bool _useMaterialYou;
 
     private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
 
@@ -259,15 +259,15 @@ public partial class MainWindow : Window
         UpdateMemoryDisplay();
     }
 
-    private void DarkModeToggle_OnChecked(object sender, RoutedEventArgs e)
+    private void MaterialThemeToggle_OnChecked(object sender, RoutedEventArgs e)
     {
-        _isDarkMode = true;
+        _useMaterialYou = true;
         ApplyTheme();
     }
 
-    private void DarkModeToggle_OnUnchecked(object sender, RoutedEventArgs e)
+    private void MaterialThemeToggle_OnUnchecked(object sender, RoutedEventArgs e)
     {
-        _isDarkMode = false;
+        _useMaterialYou = false;
         ApplyTheme();
     }
 
@@ -315,18 +315,26 @@ public partial class MainWindow : Window
 
     private void ApplyTheme()
     {
-        var windowBackground = _isDarkMode ? Color.FromRgb(18, 18, 18) : Color.FromRgb(245, 245, 245);
-        var borderBackground = _isDarkMode ? Color.FromRgb(33, 33, 33) : Colors.White;
-        var foreground = _isDarkMode ? Colors.White : Color.FromRgb(31, 31, 31);
-        var buttonBackground = _isDarkMode ? Color.FromRgb(56, 56, 56) : Color.FromRgb(224, 224, 224);
-        var accent = _isDarkMode ? Color.FromRgb(98, 0, 238) : Color.FromRgb(127, 180, 255);
+        if (_useMaterialYou)
+        {
+            Resources["WindowBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(18, 17, 23));
+            Resources["BorderBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(33, 31, 42));
+            Resources["BorderForegroundBrush"] = new SolidColorBrush(Color.FromRgb(238, 233, 255));
+            Resources["ButtonBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(55, 51, 64));
+            Resources["ButtonForegroundBrush"] = new SolidColorBrush(Color.FromRgb(238, 233, 255));
+            Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(154, 139, 255));
+        }
+        else
+        {
+            Resources["WindowBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(18, 18, 18));
+            Resources["BorderBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(31, 31, 31));
+            Resources["BorderForegroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+            Resources["ButtonBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(42, 42, 42));
+            Resources["ButtonForegroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+            Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(61, 125, 255));
+        }
 
-        Resources["WindowBackgroundBrush"] = new SolidColorBrush(windowBackground);
-        Resources["BorderBackgroundBrush"] = new SolidColorBrush(borderBackground);
-        Resources["BorderForegroundBrush"] = new SolidColorBrush(foreground);
-        Resources["ButtonBackgroundBrush"] = new SolidColorBrush(buttonBackground);
-        Resources["ButtonForegroundBrush"] = new SolidColorBrush(foreground);
-        Resources["AccentButtonBrush"] = new SolidColorBrush(accent);
+        MaterialThemeToggle.Content = _useMaterialYou ? "Material You nézet" : "Klasszikus nézet";
     }
 
     private void ResetCalculatorState()


### PR DESCRIPTION
## Summary
- update the default classic resources to a dark palette and restyle the theme toggle button
- keep the Material You palette dark-only while harmonising colors between the two themes
- synchronise the toggle label with the active view when switching themes

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e27fe17f048325ad782d85c33f9cb8