### PR TITLE
Fix MainWindow theme toggle build errors

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -70,11 +70,6 @@
                           Unchecked="MaterialThemeToggle_OnUnchecked"
                           Foreground="{DynamicResource BorderForegroundBrush}"
                           Background="{DynamicResource ButtonBackgroundBrush}" />
-
-            <ToggleButton x:Name="MaterialThemeToggle" Content="Material You" Grid.Column="1" Margin="12,0,0,0"
-                          VerticalAlignment="Center" Padding="12,8" Checked="MaterialThemeToggle_OnChecked"
-                          Unchecked="MaterialThemeToggle_OnUnchecked"
-                          Foreground="{DynamicResource BorderForegroundBrush}" />
          
         </Grid>
 

--- a/CalcApp/MainWindow.xaml.cs
+++ b/CalcApp/MainWindow.xaml.cs
@@ -317,32 +317,12 @@ public partial class MainWindow : Window
     {
         if (_useMaterialYou)
         {
-
             Resources["WindowBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(18, 17, 23));
             Resources["BorderBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(33, 31, 42));
             Resources["BorderForegroundBrush"] = new SolidColorBrush(Color.FromRgb(238, 233, 255));
             Resources["ButtonBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(55, 51, 64));
             Resources["ButtonForegroundBrush"] = new SolidColorBrush(Color.FromRgb(238, 233, 255));
             Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(154, 139, 255));
-        }
-        else
-        {
-            Resources["WindowBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(18, 18, 18));
-            Resources["BorderBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(31, 31, 31));
-            Resources["BorderForegroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
-            Resources["ButtonBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(42, 42, 42));
-            Resources["ButtonForegroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
-            Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(61, 125, 255));
-        }
-
-        MaterialThemeToggle.Content = _useMaterialYou ? "Material You nézet" : "Klasszikus nézet";
-
-            Resources["WindowBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(18, 18, 18));
-            Resources["BorderBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(28, 27, 31));
-            Resources["BorderForegroundBrush"] = new SolidColorBrush(Color.FromRgb(232, 224, 255));
-            Resources["ButtonBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(49, 48, 56));
-            Resources["ButtonForegroundBrush"] = new SolidColorBrush(Color.FromRgb(232, 224, 255));
-            Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(147, 118, 255));
         }
         else
         {
@@ -354,6 +334,7 @@ public partial class MainWindow : Window
             Resources["AccentButtonBrush"] = new SolidColorBrush(Color.FromRgb(127, 180, 255));
         }
 
+        MaterialThemeToggle.Content = _useMaterialYou ? "Material You nézet" : "Klasszikus nézet";
     }
 
     private void ResetCalculatorState()


### PR DESCRIPTION
## Summary
- remove the duplicate MaterialThemeToggle declaration from the XAML so the generated field is available in code-behind
- simplify ApplyTheme so it only applies one set of resources per mode and updates the toggle text, resolving the merge remnants that broke the build

## Testing
- `dotnet build` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e286e7c59083259d26b834dcf7d11d