### PR TITLE
Remove duplicate InitializeComponent definition

### DIFF
--- a/CalcApp/MainWindow.xaml.cs
+++ b/CalcApp/MainWindow.xaml.cs
@@ -27,12 +27,6 @@ public partial class MainWindow : Window
         ApplyTheme();
     }
 
-    public void InitializeComponent()
-    {
-        var resourceLocator = new Uri("/CalcApp;component/MainWindow.xaml", UriKind.Relative);
-        Application.LoadComponent(this, resourceLocator);
-    }
-
     private TextBox DisplayBox => _display ??= FindRequiredControl<TextBox>("Display");
 
     private ToggleButton MaterialThemeToggleControl =>


### PR DESCRIPTION
## Summary
- remove the manual InitializeComponent method from MainWindow to avoid duplicate definitions generated by WPF

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e28eb0a22c8325baa65ca604c8da85