### PR TITLE
Ensure WPF XAML files are compiled into the build

### DIFF
--- a/CalcApp/CalcApp.csproj
+++ b/CalcApp/CalcApp.csproj
@@ -5,5 +5,20 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+</PropertyGroup>
+
+  <ItemGroup>
+    <Page Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Compile Update="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- explicitly include App.xaml and MainWindow.xaml as Page items so MSBuild generates InitializeComponent
- tie the code-behind files to their XAML counterparts for proper designer metadata

## Testing
- Not run (environment missing .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e291e1c7448325b43a998c81dc0214