### PR TITLE
Fix duplicate WPF Page includes

### DIFF
--- a/CalcApp/CalcApp.csproj
+++ b/CalcApp/CalcApp.csproj
@@ -8,12 +8,6 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <Page Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
     <Compile Update="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
## Summary
- remove explicit Page includes from the WPF project file so the SDK implicit items can work without duplication
- retain DependentUpon links for code-behind files

## Testing
- dotnet build calc.sln *(fails: dotnet CLI is unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2933ae1ac8325b1f6aec5e74d70ea