### PR TITLE
Add scrollable memory slots list

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -77,60 +77,81 @@
                    HorizontalAlignment="Right" Foreground="{DynamicResource BorderForegroundBrush}" />
 
         <Grid Grid.Row="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <Button Content="sin" Grid.Row="0" Grid.Column="0" Click="Sin_Click" />
-            <Button Content="cos" Grid.Row="0" Grid.Column="1" Click="Cos_Click" />
-            <Button Content="tan" Grid.Row="0" Grid.Column="2" Click="Tan_Click" />
-            <Button Content="√" Grid.Row="0" Grid.Column="3" Click="Sqrt_Click" />
+            <Border Grid.Column="0" Margin="0,0,12,0" Padding="12" Width="160"
+                    Background="{DynamicResource BorderBackgroundBrush}" CornerRadius="12"
+                    BorderBrush="#FFB0B0B0" BorderThickness="1">
+                <StackPanel>
+                    <TextBlock Text="Memória helyek" FontSize="16" FontWeight="SemiBold"
+                               Margin="0,0,0,8" Foreground="{DynamicResource BorderForegroundBrush}" />
+                    <ListBox x:Name="MemoryList" SelectionChanged="MemoryList_SelectionChanged"
+                             Foreground="{DynamicResource BorderForegroundBrush}"
+                             Background="Transparent" BorderThickness="0" Height="360"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    </ListBox>
+                </StackPanel>
+            </Border>
 
-            <Button Content="n!" Grid.Row="1" Grid.Column="0" Click="Factorial_Click" />
-            <Button Content="M+" Grid.Row="1" Grid.Column="1" Click="MemoryAdd_Click" />
-            <Button Content="M-" Grid.Row="1" Grid.Column="2" Click="MemorySubtract_Click" />
-            <Button Content="MR" Grid.Row="1" Grid.Column="3" Click="MemoryRecall_Click" />
+            <Grid Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-            <Button Content="MC" Grid.Row="2" Grid.Column="0" Click="MemoryClear_Click" />
-            <Button Content="C" Grid.Row="2" Grid.Column="1" Click="Clear_Click" />
-            <Button Content="⌫" Grid.Row="2" Grid.Column="2" Click="Delete_Click" />
-            <Button Content="%" Grid.Row="2" Grid.Column="3" Click="Percent_Click" />
+                <Button Content="sin" Grid.Row="0" Grid.Column="0" Click="Sin_Click" />
+                <Button Content="cos" Grid.Row="0" Grid.Column="1" Click="Cos_Click" />
+                <Button Content="tan" Grid.Row="0" Grid.Column="2" Click="Tan_Click" />
+                <Button Content="√" Grid.Row="0" Grid.Column="3" Click="Sqrt_Click" />
 
-            <Button Content="7" Grid.Row="3" Grid.Column="0" Click="Digit_Click" />
-            <Button Content="8" Grid.Row="3" Grid.Column="1" Click="Digit_Click" />
-            <Button Content="9" Grid.Row="3" Grid.Column="2" Click="Digit_Click" />
-            <Button Content="÷" Grid.Row="3" Grid.Column="3" Click="Operator_Click" Tag="/" />
+                <Button Content="n!" Grid.Row="1" Grid.Column="0" Click="Factorial_Click" />
+                <Button Content="M+" Grid.Row="1" Grid.Column="1" Click="MemoryAdd_Click" />
+                <Button Content="M-" Grid.Row="1" Grid.Column="2" Click="MemorySubtract_Click" />
+                <Button Content="MR" Grid.Row="1" Grid.Column="3" Click="MemoryRecall_Click" />
 
-            <Button Content="4" Grid.Row="4" Grid.Column="0" Click="Digit_Click" />
-            <Button Content="5" Grid.Row="4" Grid.Column="1" Click="Digit_Click" />
-            <Button Content="6" Grid.Row="4" Grid.Column="2" Click="Digit_Click" />
-            <Button Content="×" Grid.Row="4" Grid.Column="3" Click="Operator_Click" Tag="*" />
+                <Button Content="MC" Grid.Row="2" Grid.Column="0" Click="MemoryClear_Click" />
+                <Button Content="C" Grid.Row="2" Grid.Column="1" Click="Clear_Click" />
+                <Button Content="⌫" Grid.Row="2" Grid.Column="2" Click="Delete_Click" />
+                <Button Content="%" Grid.Row="2" Grid.Column="3" Click="Percent_Click" />
 
-            <Button Content="1" Grid.Row="5" Grid.Column="0" Click="Digit_Click" />
-            <Button Content="2" Grid.Row="5" Grid.Column="1" Click="Digit_Click" />
-            <Button Content="3" Grid.Row="5" Grid.Column="2" Click="Digit_Click" />
-            <Button Content="−" Grid.Row="5" Grid.Column="3" Click="Operator_Click" Tag="-" />
+                <Button Content="7" Grid.Row="3" Grid.Column="0" Click="Digit_Click" />
+                <Button Content="8" Grid.Row="3" Grid.Column="1" Click="Digit_Click" />
+                <Button Content="9" Grid.Row="3" Grid.Column="2" Click="Digit_Click" />
+                <Button Content="÷" Grid.Row="3" Grid.Column="3" Click="Operator_Click" Tag="/" />
 
-            <Button Content="0" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Click="Digit_Click" />
-            <Button Content="." Grid.Row="6" Grid.Column="2" Click="Decimal_Click" />
-            <Button Content="+" Grid.Row="6" Grid.Column="3" Click="Operator_Click" Tag="+" />
+                <Button Content="4" Grid.Row="4" Grid.Column="0" Click="Digit_Click" />
+                <Button Content="5" Grid.Row="4" Grid.Column="1" Click="Digit_Click" />
+                <Button Content="6" Grid.Row="4" Grid.Column="2" Click="Digit_Click" />
+                <Button Content="×" Grid.Row="4" Grid.Column="3" Click="Operator_Click" Tag="*" />
 
-            <Button Content="±" Grid.Row="7" Grid.Column="0" Click="Sign_Click" />
-            <Button Content="=" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Click="Equals_Click"
-                    Background="{DynamicResource AccentButtonBrush}" />
+                <Button Content="1" Grid.Row="5" Grid.Column="0" Click="Digit_Click" />
+                <Button Content="2" Grid.Row="5" Grid.Column="1" Click="Digit_Click" />
+                <Button Content="3" Grid.Row="5" Grid.Column="2" Click="Digit_Click" />
+                <Button Content="−" Grid.Row="5" Grid.Column="3" Click="Operator_Click" Tag="-" />
+
+                <Button Content="0" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Click="Digit_Click" />
+                <Button Content="." Grid.Row="6" Grid.Column="2" Click="Decimal_Click" />
+                <Button Content="+" Grid.Row="6" Grid.Column="3" Click="Operator_Click" Tag="+" />
+
+                <Button Content="±" Grid.Row="7" Grid.Column="0" Click="Sign_Click" />
+                <Button Content="=" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Click="Equals_Click"
+                        Background="{DynamicResource AccentButtonBrush}" />
+            </Grid>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- add a dedicated, scrollable memory list to the calculator layout
- manage ten independent memory slots with selection-aware operations and display updates

## Testing
- dotnet build CalcApp/CalcApp.csproj *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29ed99a988325a6b9647bfbd2f19a