### PR TITLE
Expand memory section size

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -82,7 +82,7 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Margin="0,0,12,0" Padding="12" Width="160"
+            <Border Grid.Column="0" Margin="0,0,12,0" Padding="12" Width="220"
                     Background="{DynamicResource BorderBackgroundBrush}" CornerRadius="12"
                     BorderBrush="#FFB0B0B0" BorderThickness="1">
                 <StackPanel>
@@ -90,7 +90,7 @@
                                Margin="0,0,0,8" Foreground="{DynamicResource BorderForegroundBrush}" />
                     <ListBox x:Name="MemoryList" SelectionChanged="MemoryList_SelectionChanged"
                              Foreground="{DynamicResource BorderForegroundBrush}"
-                             Background="Transparent" BorderThickness="0" Height="360"
+                             Background="Transparent" BorderThickness="0" Height="420"
                              ScrollViewer.VerticalScrollBarVisibility="Auto">
                     </ListBox>
                 </StackPanel>


### PR DESCRIPTION
## Summary
- widen the memory list panel so stored values are easier to read
- increase the memory list height to show more entries without scrolling

## Testing
- ❌ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a77d54008325a1cb9227553d2b2a