### PR TITLE
Move memory panel below keypad with draggable splitter

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -77,26 +77,13 @@
                    HorizontalAlignment="Right" Foreground="{DynamicResource BorderForegroundBrush}" />
 
         <Grid Grid.Row="2">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="0" MinHeight="0" />
+            </Grid.RowDefinitions>
 
-            <Border Grid.Column="0" Margin="0,0,12,0" Padding="12" Width="220"
-                    Background="{DynamicResource BorderBackgroundBrush}" CornerRadius="12"
-                    BorderBrush="#FFB0B0B0" BorderThickness="1">
-                <StackPanel>
-                    <TextBlock Text="Memória helyek" FontSize="16" FontWeight="SemiBold"
-                               Margin="0,0,0,8" Foreground="{DynamicResource BorderForegroundBrush}" />
-                    <ListBox x:Name="MemoryList" SelectionChanged="MemoryList_SelectionChanged"
-                             Foreground="{DynamicResource BorderForegroundBrush}"
-                             Background="Transparent" BorderThickness="0" Height="420"
-                             ScrollViewer.VerticalScrollBarVisibility="Auto">
-                    </ListBox>
-                </StackPanel>
-            </Border>
-
-            <Grid Grid.Column="1">
+            <Grid Grid.Row="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />
                     <RowDefinition Height="*" />
@@ -152,6 +139,27 @@
                 <Button Content="=" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Click="Equals_Click"
                         Background="{DynamicResource AccentButtonBrush}" />
             </Grid>
+
+            <GridSplitter Grid.Row="1" Height="10" Margin="0,12,0,12" HorizontalAlignment="Stretch"
+                          Background="#44FFFFFF" ShowsPreview="True" ResizeDirection="Rows"
+                          ResizeBehavior="PreviousAndNext" Cursor="SizeNS" />
+
+            <Border Grid.Row="2" Padding="12" Background="{DynamicResource BorderBackgroundBrush}"
+                    CornerRadius="12" BorderBrush="#FFB0B0B0" BorderThickness="1"
+                    SnapsToDevicePixels="True">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <TextBlock Text="Memória helyek" FontSize="16" FontWeight="SemiBold"
+                               Margin="0,0,0,8" Foreground="{DynamicResource BorderForegroundBrush}" />
+                    <ListBox x:Name="MemoryList" Grid.Row="1" SelectionChanged="MemoryList_SelectionChanged"
+                             Foreground="{DynamicResource BorderForegroundBrush}"
+                             Background="Transparent" BorderThickness="0"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto" />
+                </Grid>
+            </Border>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- replace the left-hand memory column with a bottom panel revealed by a horizontal grid splitter
- keep the keypad at full width so the memory list can be shown by dragging from the bottom when needed

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3eb164f68832c84b19b977da43da9