### PR TITLE
Simplify memory storage to single slot

### DIFF
--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -152,9 +152,9 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <TextBlock Text="Memória helyek" FontSize="16" FontWeight="SemiBold"
+                    <TextBlock Text="Memória" FontSize="16" FontWeight="SemiBold"
                                Margin="0,0,0,8" Foreground="{DynamicResource BorderForegroundBrush}" />
-                    <ListBox x:Name="MemoryList" Grid.Row="1" SelectionChanged="MemoryList_SelectionChanged"
+                    <ListBox x:Name="MemoryList" Grid.Row="1"
                              Foreground="{DynamicResource BorderForegroundBrush}"
                              Background="Transparent" BorderThickness="0"
                              ScrollViewer.VerticalScrollBarVisibility="Auto" />


### PR DESCRIPTION
## Summary
- update the memory panel label to simply "Memória" and remove multi-slot selection hooks
- refactor memory logic to track a single memory value with operation history text

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ef3467d8832c99b7a63b727c2c1b