### PR TITLE
Refactor theme resources and optimize memory tracking

### DIFF
--- a/CalcApp/CalcApp.csproj
+++ b/CalcApp/CalcApp.csproj
@@ -15,4 +15,9 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="Themes\ClassicTheme.xaml" />
+    <Page Include="Themes\MaterialTheme.xaml" />
+  </ItemGroup>
 </Project>

--- a/CalcApp/MainWindow.xaml
+++ b/CalcApp/MainWindow.xaml
@@ -4,44 +4,43 @@
         Title="Calculator" Width="380" MinWidth="360" Height="560" MinHeight="520" ResizeMode="CanResize"
         Background="{DynamicResource WindowBackgroundBrush}">
     <Window.Resources>
-        <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FF121212" />
-        <SolidColorBrush x:Key="BorderBackgroundBrush" Color="#FF1F1F1F" />
-        <SolidColorBrush x:Key="BorderForegroundBrush" Color="#FFF2F2F2" />
-        <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FF2A2A2A" />
-        <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FFF2F2F2" />
-        <SolidColorBrush x:Key="AccentButtonBrush" Color="#FF3D7DFF" />
-        <Style TargetType="Button">
-            <Setter Property="Margin" Value="4" />
-            <Setter Property="FontSize" Value="18" />
-            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}" />
-            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundBrush}" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Padding" Value="8" />
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border x:Name="ButtonBorder"
-                                Background="{TemplateBinding Background}"
-                                CornerRadius="14"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}">
-                            <ContentPresenter HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              RecognizesAccessKey="True" />
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.85" />
-                            </Trigger>
-                            <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.6" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/ClassicTheme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="Button">
+                <Setter Property="Margin" Value="4" />
+                <Setter Property="FontSize" Value="18" />
+                <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundBrush}" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Padding" Value="8" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="ButtonBorder"
+                                    Background="{TemplateBinding Background}"
+                                    CornerRadius="14"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}">
+                                <ContentPresenter HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  RecognizesAccessKey="True" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.85" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="ButtonBorder" Property="Opacity" Value="0.6" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
     </Window.Resources>
 
     <Grid Margin="12">

--- a/CalcApp/Themes/ClassicTheme.xaml
+++ b/CalcApp/Themes/ClassicTheme.xaml
@@ -1,0 +1,9 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FFF5F5F5" />
+    <SolidColorBrush x:Key="BorderBackgroundBrush" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="BorderForegroundBrush" Color="#FF1F1F1F" />
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FFE0E0E0" />
+    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FF1F1F1F" />
+    <SolidColorBrush x:Key="AccentButtonBrush" Color="#FF7FB4FF" />
+</ResourceDictionary>

--- a/CalcApp/Themes/MaterialTheme.xaml
+++ b/CalcApp/Themes/MaterialTheme.xaml
@@ -1,0 +1,9 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FF121117" />
+    <SolidColorBrush x:Key="BorderBackgroundBrush" Color="#FF211F2A" />
+    <SolidColorBrush x:Key="BorderForegroundBrush" Color="#FFEEE9FF" />
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#FF373340" />
+    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FFEEE9FF" />
+    <SolidColorBrush x:Key="AccentButtonBrush" Color="#FF9A8BFF" />
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- move theme brushes into dedicated resource dictionaries and include them in the project
- cache and swap theme dictionaries at runtime to avoid recreating brushes and to keep the toggle label in sync
- streamline memory history tracking by replacing the List<string> join with an incremental StringBuilder update

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e416ec432c832ca1944f4835b6d50b