### PR TITLE
Clear last operation description when resetting memory

### DIFF
--- a/CalcApp/ViewModels/CalculatorViewModel.cs
+++ b/CalcApp/ViewModels/CalculatorViewModel.cs
@@ -678,6 +678,7 @@ public sealed class CalculatorViewModel : BaseViewModel
         _memoryValue = 0;
         _memoryHistoryEntries.Clear();
         _memoryHistoryText = string.Empty;
+        _lastOperationDescription = null;
         UpdateMemoryDisplay();
     }
 


### PR DESCRIPTION
### Motivation
- Resetting memory should also clear any stale `_lastOperationDescription` so subsequent memory history entries reflect current values rather than an old operation.

### Description
- Added `_lastOperationDescription = null;` to `ResetMemory()` in `CalcApp/ViewModels/CalculatorViewModel.cs` to ensure memory history entries use the current value; no external skills were used.

### Testing
- Attempted to run `dotnet test` but `dotnet` is not available in the execution environment, so automated tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ab5318988325bdd05231f12367ff)